### PR TITLE
Use Powershell Core for module packaging

### DIFF
--- a/pipelines/templates/dotnetclient.yml
+++ b/pipelines/templates/dotnetclient.yml
@@ -73,6 +73,7 @@ jobs:
     - task: PowerShell@2
       displayName: generate cmdlet
       inputs:
+        pwsh: true
         filePath: 'build/build-cmdlet.ps1'
         arguments: '-Configuration $(BuildConfiguration) -OutputDir $(Build.ArtifactStagingDirectory)' 
 


### PR DESCRIPTION
This PR changes the used Powershell version to Powershell Core which supports additional features.