### PR TITLE
Migrate dotnet client template to GitVersion 6 (GitHub-flow)

### DIFF
--- a/docs/gitversion-versioning.md
+++ b/docs/gitversion-versioning.md
@@ -2,15 +2,25 @@
 
 ## TL;DR
 
-The .NET client repos (those that `extends` [`pipelines/templates/dotnetclient.yml`](../pipelines/templates/dotnetclient.yml))
-are **pinned to GitVersion 5.11.x**. Do **not** bump them to GitVersion 6 without
-first migrating every consumer's `gitversion.yml` **and** solving pre-release-tag
-handling. A naive bump silently breaks versioning:
+The .NET client repos `extends` [`pipelines/templates/dotnetclient.yml`](../pipelines/templates/dotnetclient.yml).
+They were **pinned to GitVersion 5.11.x** because a naive bump to GitVersion 6
+silently breaks versioning:
 
 * untagged `main` builds publish **released** versions (`0.15.0`) instead of
   CI pre-releases (`0.15.0-ci.<n>`), and
 * release tags such as `v0.15.0-beta.1` are **not** honoured — they finalize to
   a stable `0.15.0`.
+
+A **validated permanent fix** now exists (see
+[Permanent fix on GitVersion 6](#permanent-fix-on-gitversion-6)). In short:
+GitVersion computes **branch (CI) builds** only; **tag builds take the version
+verbatim from the tag name** and skip GitVersion entirely. This is the only way
+to satisfy all rows below on GitVersion 6 — a maintainer has
+[confirmed](https://github.com/GitTools/GitVersion/discussions/4696) that a single
+GitVersion config cannot produce both `ci`-on-`main` **and** verbatim pre-release
+tags. The template change must be rolled out **together** with the per-consumer
+migration (`gitversion.yml` v6 schema + `GitVersion.MsBuild` 6.x), because builds
+resolve the template from `build`'s default branch at queue time.
 
 The desired behaviour is:
 
@@ -179,20 +189,86 @@ module prerelease `beta0020`.
 > then run GitVersion. The plain (LocalBuild) runs above already demonstrate the
 > version contrast without that setup.
 
-## If/when migrating to GitVersion 6
+## Permanent fix on GitVersion 6
 
-A clean v6 migration must, **for every consumer at once**:
+The shared template now targets **GitVersion 6.7.x** using a split that matches
+the GitHub-flow release model (CI pre-releases on `main`, named tags = releases):
 
-1. Rewrite each `gitversion.yml` to the v6 schema — move `mode` under
-   `branches: main:` and use **`ContinuousDelivery`** (not `ContinuousDeployment`)
-   with `label: ci` to keep `X.Y.Z-ci.<n>`.
-2. Bump `GitVersion.MsBuild` to the matching 6.x in every `Directory.Build.props`.
-3. Replace the removed `NuGet*` variables in the PS-module packaging — build the
-   alphanumeric prerelease from `PreReleaseLabel` + zero-padded `PreReleaseNumber`.
-4. **Solve pre-release tags**, which v6 will not honour on `main`. The robust
-   option is a template step that, for `refs/tags/v*` builds, derives the version
-   directly from the tag name (strip the leading `v`) instead of letting
-   GitVersion recompute it.
+* **Branch (CI) builds** — GitVersion computes the version. With the v6 config
+  below, `main` produces `X.Y.Z-ci.<n>`.
+* **Tag builds (`refs/tags/v*`)** — the version is taken **verbatim from the tag
+  name** (minus the leading `v`). GitVersion is **not** run at all: the
+  `gitversion/execute` task is skipped, and `GitVersion.MsBuild` is disabled
+  during `pack` via `-p:DisableGitVersionTask=true -p:Version=<tag>`.
 
-Validate the full matrix in the test repo above before changing the shared
-template, since the template change affects all consumers simultaneously.
+### Why tag builds must bypass GitVersion
+
+This is **by design** in GitVersion 6, not a misconfiguration on our side:
+
+* A pre-release tag's label is only honoured when it **matches the branch's
+  configured `label`** (v6
+  [BREAKING_CHANGES](https://github.com/GitTools/GitVersion/blob/main/BREAKING_CHANGES.md)).
+  So `label: ci` (needed for CI builds) makes v6 **relabel** a `beta` tag to
+  `ci`, or finalise it to stable. `label: ''`/`null` loses the `ci` label.
+  Verified with all three label modes — none satisfy the matrix.
+* A GitVersion maintainer has
+  [confirmed](https://github.com/GitTools/GitVersion/discussions/4696) (Oct 2025)
+  that producing `ci` on untagged commits **and** verbatim pre-release tags from
+  one config is *"not possible"*.
+* On Azure DevOps, tag builds check out a **detached HEAD** with
+  `BUILD_SOURCEBRANCH=refs/tags/v*`; GitVersion 6 then falls back to `-no-branch-`
+  ([#4534](https://github.com/GitTools/GitVersion/issues/4534), closed without a
+  fix). Bypassing GitVersion for tags sidesteps this entirely.
+
+This combination (CI-on-`main` + tag-as-release-version on Azure DevOps) has been
+reported upstream repeatedly since 2020 (e.g.
+[#2231](https://github.com/GitTools/GitVersion/issues/2231),
+[#2362](https://github.com/GitTools/GitVersion/issues/2362),
+[#4015](https://github.com/GitTools/GitVersion/issues/4015)) and never got a
+complete upstream fix; deriving the version from the tag is the accepted
+pragmatic solution.
+
+> **Alternative considered — `label: beta`.** Setting `main`'s `label: beta`
+> reproduces v5 behaviour (verbatim `beta` tags *and* beta lineage) with no
+> pipeline logic, but labels untagged CI builds `beta.<n>` instead of `ci.<n>`
+> and silently relabels any non-`beta` pre-release tag (`alpha`, `rc`). Rejected
+> because we want `ci` for CI builds and a label-agnostic release path.
+
+### Validation
+
+Proven end-to-end on real Azure DevOps builds (GitVersion 6.7.0), at both the
+pipeline level (build number) and the package level (`dotnet pack` output):
+
+| Scenario                               | Checkout      | Version produced  |
+| -------------------------------------- | ------------- | ----------------- |
+| commit on `main` (untagged)            | normal        | `X.Y.Z-ci.<n>`    |
+| tag `vX.Y.Z-beta.1`                    | detached HEAD | `X.Y.Z-beta.1`    |
+| tag `vX.Y.Z`                           | detached HEAD | `X.Y.Z`           |
+
+Note: untagged CI builds after a pre-release tag now carry `-ci.<n>` (not the v5
+`-beta.<n>` lineage). NuGet ordering is preserved (`beta` < `ci`), and CI builds
+go to the internal feed while releases come from tags, so they do not collide.
+
+### Per-consumer migration (required, all consumers together)
+
+The template change must land **with** these per-consumer changes, since builds
+resolve the template from `build`'s default branch at queue time:
+
+1. Rewrite each `gitversion.yml` to the v6 schema:
+   ```yaml
+   assembly-versioning-scheme: MajorMinor
+   branches:
+     main:
+       deployment-mode: ContinuousDelivery   # v5 'ContinuousDeployment' == v6 'ContinuousDelivery'
+       label: ci
+   ```
+2. Bump `GitVersion.MsBuild` to **6.7.x** in every `Directory.Build.props`.
+3. **`withCmdlet` repos only:** the PS-module packaging uses the removed
+   `GitVersion_NuGetPreReleaseTag` (e.g. `beta0020`). Rebuild it in
+   `build/build-cmdlet.ps1` — for branch builds from `PreReleaseLabel` +
+   zero-padded `PreReleaseNumber`; for tag builds from the tag's pre-release
+   component. This is **not** solved by the template and must be handled in each
+   cmdlet-producing consumer.
+
+The repro harness in [Clean reproduction on a test repo](#clean-reproduction-on-a-test-repo)
+above validates the matrix locally before any consumer is changed.

--- a/docs/gitversion-versioning.md
+++ b/docs/gitversion-versioning.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-The .NET client repos `extends` [`pipelines/templates/dotnetclient.yml`](../pipelines/templates/dotnetclient.yml).
+The .NET client repos extend [`pipelines/templates/dotnetclient.yml`](../pipelines/templates/dotnetclient.yml).
 They were **pinned to GitVersion 5.11.x** because a naive bump to GitVersion 6
 silently breaks versioning:
 

--- a/docs/gitversion-versioning.md
+++ b/docs/gitversion-versioning.md
@@ -262,13 +262,24 @@ resolve the template from `build`'s default branch at queue time:
        deployment-mode: ContinuousDelivery   # v5 'ContinuousDeployment' == v6 'ContinuousDelivery'
        label: ci
    ```
-2. Bump `GitVersion.MsBuild` to **6.7.x** in every `Directory.Build.props`.
-3. **`withCmdlet` repos only:** the PS-module packaging uses the removed
-   `GitVersion_NuGetPreReleaseTag` (e.g. `beta0020`). Rebuild it in
-   `build/build-cmdlet.ps1` — for branch builds from `PreReleaseLabel` +
-   zero-padded `PreReleaseNumber`; for tag builds from the tag's pre-release
-   component. This is **not** solved by the template and must be handled in each
-   cmdlet-producing consumer.
+2. Bump `GitVersion.MsBuild` to **6.7.x** in every `Directory.Build.props` (or, for
+   repos without one, in each project file — e.g. `dotnet-commonclient`).
+
+That is the **entire** per-consumer change. The PowerShell-module versioning
+(`withCmdlet` repos) is handled **centrally by the template**: GitVersion 6 dropped
+the `GitVersion_NuGet*` outputs, so the template reconstructs `NuGetPreReleaseTag`
+(`label` + 4-digit zero-padded number, e.g. `ci0001`, `beta0020`) and `MajorMinorPatch`
+for **both** build kinds and injects them —
+
+* as MSBuild properties (`-p:GitVersion_MajorMinorPatch=… -p:GitVersion_NuGetPreReleaseTag=…`)
+  for repos that stamp the module during build via `Prepare-PsModule.ps1`
+  (`dotnet-computeclient`, `dotnet-clientruntime`, `dotnet-identityclient`), and
+* as `GITVERSION_*` pipeline/environment variables for repos whose cmdlet step reads
+  them directly (`dotnet-commonclient`).
+
+So `Prepare-PsModule.ps1` / `build-cmdlet.ps1` keep working unchanged. On tag builds
+this matters doubly: GitVersion.MsBuild is disabled there, so without the injected
+`GitVersion_MajorMinorPatch` the module build would fail its version validation.
 
 The repro harness in [Clean reproduction on a test repo](#clean-reproduction-on-a-test-repo)
 above validates the matrix locally before any consumer is changed.

--- a/pipelines/templates/dotnetclient.yml
+++ b/pipelines/templates/dotnetclient.yml
@@ -45,8 +45,11 @@ jobs:
       Write-Host "Build.SourceBranch = $src"
       if ($src -like 'refs/tags/v*') {
           $ver = $src.Substring('refs/tags/v'.Length)
-          if ($ver -match '\+') {
-              Write-Error "Tag '$src' contains build metadata ('+'); not a valid NuGet package version."
+          # Accept only a plain SemVer (optionally with a pre-release label). This rejects
+          # empty/malformed tags, build metadata ('+'), and any characters that could be
+          # injected into the ##vso[...] logging commands or MSBuild properties below.
+          if ($ver -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
+              Write-Error "Tag '$src' is not a valid release version (expected vX.Y.Z[-prerelease])."
               exit 1
           }
           Write-Host "Tag build -> released version: $ver"

--- a/pipelines/templates/dotnetclient.yml
+++ b/pipelines/templates/dotnetclient.yml
@@ -52,10 +52,23 @@ jobs:
               Write-Error "Tag '$src' is not a valid release version (expected vX.Y.Z[-prerelease])."
               exit 1
           }
-          Write-Host "Tag build -> released version: $ver"
+          # Reconstruct the PowerShell-module version parts (GitVersion 6 dropped the
+          # NuGet* outputs). NuGetPreReleaseTag = label + 4-digit zero-padded number,
+          # matching GitVersion 5 (e.g. v0.15.0-beta.1 -> beta0001, v0.16.0 -> stable).
+          $mmp = ($ver -split '-', 2)[0]
+          $psTag = ''
+          if ($ver -match '-([A-Za-z]+)[.\-]?([0-9]+)') {
+              $psTag = $matches[1] + $matches[2].PadLeft(4, '0')
+          } elseif ($ver -match '-(.+)$') {
+              $psTag = ($matches[1] -replace '[^0-9A-Za-z]', '')
+          }
+          Write-Host "Tag build -> $ver (MajorMinorPatch=$mmp, NuGetPreReleaseTag=$psTag)"
           Write-Host "##vso[task.setvariable variable=isTagBuild]true"
-          Write-Host "##vso[task.setvariable variable=versionBuildArgs]-p:DisableGitVersionTask=true -p:Version=$ver"
-          Write-Host "##vso[task.setvariable variable=versionPackProps]DisableGitVersionTask=true;Version=$ver"
+          Write-Host "##vso[task.setvariable variable=versionBuildArgs]-p:DisableGitVersionTask=true -p:Version=$ver -p:GitVersion_MajorMinorPatch=$mmp -p:GitVersion_NuGetPreReleaseTag=$psTag"
+          Write-Host "##vso[task.setvariable variable=versionPackProps]DisableGitVersionTask=true;Version=$ver;GitVersion_MajorMinorPatch=$mmp;GitVersion_NuGetPreReleaseTag=$psTag"
+          # Env vars for repos whose cmdlet step reads GITVERSION_* (e.g. dotnet-commonclient).
+          Write-Host "##vso[task.setvariable variable=GITVERSION_MajorMinorPatch]$mmp"
+          Write-Host "##vso[task.setvariable variable=GITVERSION_NuGetPreReleaseTag]$psTag"
           Write-Host "##vso[build.updatebuildnumber]$ver"
       } else {
           Write-Host "Branch build -> GitVersion computes the version"
@@ -68,6 +81,22 @@ jobs:
   # Branch (CI) builds only. On tag builds the version comes from the tag (above).
   - task: gitversion/execute@3
     displayName: Execute GitVersion
+    condition: ne(variables['isTagBuild'], 'true')
+
+  # Branch builds: rebuild the NuGetPreReleaseTag that GitVersion 6 no longer emits,
+  # from the v6 PreReleaseLabel + PreReleaseNumber (e.g. ci + 1 -> ci0001). MajorMinorPatch
+  # still comes from GitVersion.MsBuild during build; only the pre-release label is injected.
+  - pwsh: |
+      $label = '$(GitVersion.PreReleaseLabel)'
+      $number = 0; [void][int]::TryParse('$(GitVersion.PreReleaseNumber)', [ref]$number)
+      $psTag = ''
+      if (-not [string]::IsNullOrWhiteSpace($label)) { $psTag = $label + $number.ToString('0000') }
+      Write-Host "Branch build -> MajorMinorPatch=$(GitVersion.MajorMinorPatch), NuGetPreReleaseTag=$psTag"
+      Write-Host "##vso[task.setvariable variable=versionBuildArgs]-p:GitVersion_NuGetPreReleaseTag=$psTag"
+      Write-Host "##vso[task.setvariable variable=versionPackProps]GitVersion_NuGetPreReleaseTag=$psTag"
+      Write-Host "##vso[task.setvariable variable=GITVERSION_MajorMinorPatch]$(GitVersion.MajorMinorPatch)"
+      Write-Host "##vso[task.setvariable variable=GITVERSION_NuGetPreReleaseTag]$psTag"
+    displayName: 'Compose PowerShell module version (branch builds)'
     condition: ne(variables['isTagBuild'], 'true')
 
   - task: DotNetCoreCLI@2

--- a/pipelines/templates/dotnetclient.yml
+++ b/pipelines/templates/dotnetclient.yml
@@ -1,4 +1,4 @@
-  
+
 # dotnet client build pipeline
 
 parameters:
@@ -14,19 +14,58 @@ trigger:
 jobs:
 - job: Build
   pool:
-    vmImage: windows-latest  
+    vmImage: windows-latest
 
   variables:
     buildConfiguration: 'Release'
 
   steps:
-  - task: gitversion/setup@3.1.11
+  # fetchDepth: 0 -> full history + tags so GitVersion can compute CI builds.
+  # The default shallow checkout hides the baseline tag and yields 0.0.1-ci.<n>.
+  - checkout: self
+    fetchDepth: 0
+
+  # The task is pinned to the @3 major (latest 3.x); GitVersion 6.6+ requires it
+  # (the older @3.1.11 caps the CLI at < 6.1.0). The CLI itself is pinned via versionSpec.
+  - task: gitversion/setup@3
     displayName: Install GitVersion
     inputs:
-      versionSpec: '5.11.x'
+      versionSpec: '6.7.x'
 
-  - task: gitversion/execute@3.1.11
+  # GitHub-flow version resolution:
+  #   refs/tags/v*  -> released version taken verbatim from the tag name (minus 'v').
+  #                    GitVersion is NOT used for tag builds - neither this task (skipped
+  #                    below) nor GitVersion.MsBuild during pack (DisableGitVersionTask).
+  #                    This honours pre-release tags verbatim (which GitVersion 6 would
+  #                    otherwise relabel/finalise) and sidesteps the Azure detached-HEAD
+  #                    bug GitTools/GitVersion#4534.
+  #   anything else -> CI build; GitVersion computes X.Y.Z-ci.<n>.
+  - powershell: |
+      $src = "$(Build.SourceBranch)"
+      Write-Host "Build.SourceBranch = $src"
+      if ($src -like 'refs/tags/v*') {
+          $ver = $src.Substring('refs/tags/v'.Length)
+          if ($ver -match '\+') {
+              Write-Error "Tag '$src' contains build metadata ('+'); not a valid NuGet package version."
+              exit 1
+          }
+          Write-Host "Tag build -> released version: $ver"
+          Write-Host "##vso[task.setvariable variable=isTagBuild]true"
+          Write-Host "##vso[task.setvariable variable=versionBuildArgs]-p:DisableGitVersionTask=true -p:Version=$ver"
+          Write-Host "##vso[task.setvariable variable=versionPackProps]DisableGitVersionTask=true;Version=$ver"
+          Write-Host "##vso[build.updatebuildnumber]$ver"
+      } else {
+          Write-Host "Branch build -> GitVersion computes the version"
+          Write-Host "##vso[task.setvariable variable=isTagBuild]false"
+          Write-Host "##vso[task.setvariable variable=versionBuildArgs]"
+          Write-Host "##vso[task.setvariable variable=versionPackProps]"
+      }
+    displayName: 'Resolve version source'
+
+  # Branch (CI) builds only. On tag builds the version comes from the tag (above).
+  - task: gitversion/execute@3
     displayName: Execute GitVersion
+    condition: ne(variables['isTagBuild'], 'true')
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
@@ -41,7 +80,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --no-restore'
+      arguments: '--configuration $(buildConfiguration) --no-restore $(versionBuildArgs)'
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -57,6 +96,7 @@ jobs:
       packagesToPack: '**/*.csproj'
       packDirectory: '$(Build.ArtifactStagingDirectory)\packages'
       versioningScheme: 'off'
+      buildProperties: '$(versionPackProps)'
 
   - task: PublishBuildArtifacts@1
     displayName: publish nuget artifacts
@@ -71,7 +111,7 @@ jobs:
       command: 'push'
       packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
       nuGetFeedType: 'internal'
-      publishVstsFeed: '59a3608a-9bed-4cb4-9467-6efaaa3cbef5/1e425ef4-e3a0-4927-b4c0-2beff753cb88'   
+      publishVstsFeed: '59a3608a-9bed-4cb4-9467-6efaaa3cbef5/1e425ef4-e3a0-4927-b4c0-2beff753cb88'
 
   - ${{ if eq(parameters.withCmdlet, true) }}:
     - task: PowerShell@2
@@ -79,7 +119,7 @@ jobs:
       inputs:
         pwsh: true
         filePath: 'build/build-cmdlet.ps1'
-        arguments: '-Configuration $(BuildConfiguration) -OutputDir $(Build.ArtifactStagingDirectory)' 
+        arguments: '-Configuration $(BuildConfiguration) -OutputDir $(Build.ArtifactStagingDirectory)'
 
     - task: PublishBuildArtifacts@1
       displayName: publish cmdlet artifacts
@@ -87,5 +127,5 @@ jobs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)\cmdlet'
         ArtifactName: 'cmdlet'
         publishLocation: 'Container'
-    
+
 


### PR DESCRIPTION
Replaces the GitVersion 5.11.x pin with a permanent GitVersion 6.7.x setup that splits version resolution by build kind:

- **branch (CI) builds** → GitVersion computes `X.Y.Z-ci.<n>`
- **tag builds (`refs/tags/v*`)** → version taken **verbatim from the tag name** (minus `v`); GitVersion is skipped (the `execute` task is skipped and `GitVersion.MsBuild` is disabled during build/pack via `-p:DisableGitVersionTask=true -p:Version=<tag>`)

### Why tag builds bypass GitVersion
GitVersion 6 cannot honour a pre-release tag verbatim while also labelling CI builds `ci` — a tag's label is only used when it matches the branch `label` (by design; [maintainer-confirmed](https://github.com/GitTools/GitVersion/discussions/4696) that a single config can't do both). Azure detached-HEAD tag builds also hit [GitTools/GitVersion#4534](https://github.com/GitTools/GitVersion/issues/4534). Deriving the version from the tag sidesteps both.

Also adds `checkout: self` with `fetchDepth: 0` and a SemVer guard on the tag name.

### PowerShell module versioning (handled centrally)
GitVersion 6 removed the `GitVersion_NuGet*` outputs, and tag builds disable GitVersion.MsBuild — so cmdlet repos would lose their prerelease label and even fail module version validation on tag builds. The template reconstructs `MajorMinorPatch` + `NuGetPreReleaseTag` (`label` + 4-digit padded number, e.g. `ci0001`/`beta0020`, matching GitVersion 5) for both build kinds and injects them as `GitVersion_*` MSBuild properties and `GITVERSION_*` env vars. Consumer cmdlet scripts (`Prepare-PsModule.ps1` / `build-cmdlet.ps1`) need **no** changes.

### Validation
Proven end-to-end on real Azure DevOps builds (GitVersion 6.7.0), pipeline + `dotnet pack` level: `main` → `X.Y.Z-ci.<n>`; `vX.Y.Z-beta.1` (detached) → `X.Y.Z-beta.1`; `vX.Y.Z` (detached) → `X.Y.Z`.

### ⚠️ Coordinated rollout required
Builds resolve this template from `build`'s default branch **at queue time**, so this must land **together** with the per-consumer migration (one PR each, branch `chore/gitversion-6`):
1. `gitversion.yml` → v6 schema (`deployment-mode: ContinuousDelivery` + `label: ci` under `branches.main`)
2. `GitVersion.MsBuild` → 6.7.0 in every `Directory.Build.props` (commonclient: in its two project files)

Consumer PRs: computeclient#119, clientruntime#67, identityclient#34, identitymodel#48, configmodel#107, commonclient#31.

Details and rationale in `docs/gitversion-versioning.md`.